### PR TITLE
node v4 compat #6

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,14 @@ function streamPromise(stream) {
   return Promise.race(['error', 'end', 'close', 'finish'].map(on));
 }
 
-function promisePipe(...streams) {
+/**
+ * @param {...Stream} stream
+ */
+function promisePipe(stream) {
+  let i = arguments.length;
+  const streams = [];
+  while ( i-- ) streams[i] = arguments[i];
+
   const allStreams = streams
     .reduce((current, next) => current.concat(next), []);
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 class StreamError extends Error {
   constructor(err, source) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 class StreamError extends Error {
   constructor(err, source) {
-    const { message = err } = err || {};
+    const message = err && err.message || err;
     super(message);
     this.source = source;
     this.originalError = err;

--- a/test.js
+++ b/test.js
@@ -6,6 +6,7 @@ var assert = require("assert");
 var util = require("util");
 
 var promisePipe = require("./index");
+var StreamError = promisePipe.StreamError;
 
 var INPUT = __dirname + "/fixtures/input.txt";
 var OUTPUT = __dirname + "/fixtures/output.txt";
@@ -108,3 +109,19 @@ describe("promisePipe", function() {
     });
 });
 
+describe('StreamError', function() {
+    it('uses the provided error message', function() {
+        var err = new StreamError({message: 'foo'});
+        assert.equal(err.message,'foo');
+    });
+
+    it('uses assign message as error string param', function() {
+        var err = new StreamError('foo');
+        assert.equal(err.message,'foo');
+    });
+
+    it('should not throw if no message', function() {
+        var err = new StreamError();
+        assert.equal(err.message,'');
+    });
+});


### PR DESCRIPTION
Resolves #6: Node v4 support by refactoring destructured assignment and rest params. These were additional refactors needed beyond just adding `'use strict';`. Added the necessary tests.