### PR TITLE
Don't remove event listeners after an error event

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ keys:
   - `originalError`: Original error from the stream
   - `message`: The error message from original error
 
-Notice that the `promisePipe` function installs handlers for some events and cancels
-them upon return, and this may include any event handler you installed before calling
-this function.
-
 ## Example
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function streamPromise(stream) {
       const fn = evt === 'error' ?
         err => reject(new StreamError(err, stream)) :
         () => {
-          cleanupEventHandlers(stream, on);
+          cleanupEventHandlers(stream, fn);
           resolve(stream);
         };
       stream.on(evt, fn);

--- a/index.js
+++ b/index.js
@@ -9,40 +9,32 @@ class StreamError extends Error {
   }
 }
 
-// TODO: only remove the handlers we installed
-function cleanupEventHandlers(streams) {
-  const lastStream = streams[streams.length - 1];
-  streams.forEach(s => s.removeAllListeners('error'));
-  lastStream.removeAllListeners('finish');
+const events = ['error', 'end', 'close', 'finish'];
+
+function cleanupEventHandlers(stream, listener) {
+  events.map(e => stream.removeListener(e, listener));
 }
 
-// Returns a promise that is accepted when the pipe operation is done.
-function streamPromise(streams) {
-  // There only two events that interest us:
-  // * A 'finish' event emitted by the last stream in the chain, which means
-  // the chained pipe operations are done, and the last stream has been
-  // flushed and ended.
-  // * An 'error' event from any stream, when something goes wrong.
-  return Promise.race([
-    new Promise((accept, reject) => {
-      const stream = streams[streams.length - 1];
-      if (stream === process.stdout || stream === process.stderr) {
-        accept();
-      }
-      stream.once('finish', accept);
-    }),
-    Promise.all(streams.map(
-      stream => new Promise((accept, reject) => {
-        if (stream === process.stdout || stream === process.stderr) {
-          accept();
-        }
-        stream.once('error', err => reject(new StreamError(err, stream)));
-      })
-    ))
-  ]).then(() => {
-    cleanupEventHandlers(streams);
-    return streams;
-  });
+function streamPromise(stream) {
+  if (stream === process.stdout || stream === process.stderr) {
+    return Promise.resolve(stream);
+  }
+
+  function on(evt) {
+    function executor(resolve, reject) {
+      const fn = evt === 'error' ?
+        err => reject(new StreamError(err, stream)) :
+        () => {
+          cleanupEventHandlers(stream, on);
+          resolve(stream);
+        };
+      stream.on(evt, fn);
+    }
+
+    return new Promise(executor);
+  }
+
+  return Promise.race(events.map(on));
 }
 
 /**
@@ -55,14 +47,14 @@ function promisePipe(stream) {
 
   const allStreams = streams
     .reduce((current, next) => current.concat(next), []);
-  const promise = streamPromise(streams);
+
   allStreams.reduce((current, next) => current.pipe(next));
-  return promise;
+  return Promise.all(allStreams.map(streamPromise));
 }
 
 module.exports = Object.assign(promisePipe, {
   __esModule: true,
   default: promisePipe,
-  justPromise: streamPromise,
+  justPromise: streams => Promise.all(streams.map(streamPromise)),
   StreamError,
 });


### PR DESCRIPTION
#8 introduced a significant breaking change because there may be more than one error event emited on a single stream. Right now all subsequent errors are not handled.

This PR changes the behavior to only removing listeners on  `end`, `close`, and `finish`. I also fixed the problem with removing all listeners rather than only those added by this module, and added a test for this bug.