### PR TITLE
fix catching errors from _flush

### DIFF
--- a/fixtures/input.txt.y
+++ b/fixtures/input.txt.y
@@ -1,0 +1,1 @@
+foobarY

--- a/index.js
+++ b/index.js
@@ -9,16 +9,20 @@ class StreamError extends Error {
   }
 }
 
-const events = ['error', 'end', 'close', 'finish'];
+const allEvents = ['error', 'end', 'close', 'finish'];
+const writableEvents = ['error', 'close', 'finish'];
+const readableEvents = ['error', 'end', 'close'];
 
 function cleanupEventHandlers(stream, listener) {
-  events.map(e => stream.removeListener(e, listener));
+  allEvents.map(e => stream.removeListener(e, listener));
 }
 
 function streamPromise(stream) {
   if (stream === process.stdout || stream === process.stderr) {
     return Promise.resolve(stream);
   }
+
+  const events = stream.readable ? readableEvents : writableEvents;
 
   function on(evt) {
     function executor(resolve, reject) {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function streamPromise(stream) {
     return Promise.resolve(stream);
   }
 
-  const events = stream.readable ? readableEvents : writableEvents;
+  const events = typeof stream._read === 'function' ? readableEvents : writableEvents; // see https://github.com/epeli/node-promisepipe/issues/2
 
   function on(evt) {
     function executor(resolve, reject) {


### PR DESCRIPTION
Hello,

Promise.race listens to close, end, finish and error events whatever the type of the stream.

In the case of a Transform stream finish is emitted when all _transform calls are done, but before _flush, cf https://nodejs.org/api/stream.html#stream_events_finish_and_end

So if an error is emitted during _flush the promise is rejected after it was already resolved, resulting in a "unhandled promise rejection" error.

This commit fixes this problem and adds a test case.